### PR TITLE
Speedup

### DIFF
--- a/src/java/it/polito/appeal/traci/ChangeStateQuery.java
+++ b/src/java/it/polito/appeal/traci/ChangeStateQuery.java
@@ -92,6 +92,7 @@ public abstract class ChangeStateQuery extends Query {
 		MultiQuery multi = new MultiQuery(dos, dis);
 		multi.add(this);
 		multi.run();
+		dos.flush();
 	}
 
 }

--- a/src/java/it/polito/appeal/traci/ChangeStateQuery.java
+++ b/src/java/it/polito/appeal/traci/ChangeStateQuery.java
@@ -92,7 +92,5 @@ public abstract class ChangeStateQuery extends Query {
 		MultiQuery multi = new MultiQuery(dos, dis);
 		multi.add(this);
 		multi.run();
-		dos.flush();
 	}
-
 }

--- a/src/java/it/polito/appeal/traci/MultiQuery.java
+++ b/src/java/it/polito/appeal/traci/MultiQuery.java
@@ -100,6 +100,7 @@ public class MultiQuery {
 		}
 		
 		reqMsg.writeTo(dos);
+		dos.flush();
 		ResponseMessage respMsg = new ResponseMessage(dis);
 		Iterator<ResponseContainer> responseIterator = respMsg.responses().iterator();
 		for (Query q : queries) {

--- a/src/java/it/polito/appeal/traci/SumoTraciConnection.java
+++ b/src/java/it/polito/appeal/traci/SumoTraciConnection.java
@@ -26,6 +26,8 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
@@ -335,8 +337,8 @@ public class SumoTraciConnection {
 	}
 	
 	private void postConnect() throws IOException {
-		dis = new DataInputStream(socket.getInputStream());
-		dos = new DataOutputStream(socket.getOutputStream());
+		dis = new DataInputStream(new BufferedInputStream(socket.getInputStream()));
+		dos = new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
 
 		closeQuery = new CloseQuery(dis, dos);
 		simData = new SimulationData(dis, dos);


### PR DESCRIPTION
I wrapped DataOutputStreamd and DataInputStream in a BufferedInput/OutputStream. See [this] (http://stackoverflow.com/questions/10461302/java-sockets-datastream-really-slow) Stackoverflow post. For a simple sample scenario of 36000 steps, were an agent is added every step, the Traci4J from the master branch runs in 63000 ms, while the updated version runs in 42000 ms. 