### PR TITLE
License information / PGP signing / Compilation error in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,13 @@
 
 	<url>https://github.com/egueli/TraCI4J</url>
 
+	<licenses>
+		<license>
+			<name>GNU General Public License (GPL)</name>
+    			<url>http://www.gnu.org/licenses/gpl.txt</url>
+  		</license>
+	</licenses>
+	
 	<distributionManagement>
 		<site>
 			<id>amor.cms.hu-berlin.de</id>

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,20 @@
 					</execution>
 				</executions>
 			</plugin>
+			
+			<plugin>
+                		<groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-gpg-plugin</artifactId>
+		                <executions>
+                		    <execution>
+                        		<id>sign-artifacts</id>
+                        		<phase>verify</phase>
+                        		<goals>
+                            			<goal>sign</goal>
+		                        </goals>
+                		    </execution>
+                		</executions>
+            		</plugin>
 		</plugins>
 
 	</build>

--- a/test/java/it/polito/appeal/traci/test/RemoteTraCITest.java
+++ b/test/java/it/polito/appeal/traci/test/RemoteTraCITest.java
@@ -44,7 +44,7 @@ public class RemoteTraCITest {
 	private static final int PORT = 5450;
 	
 	@Before
-	public void setUp() throws IOException, InterruptedException {
+	public void setUp() throws Exception {
 		String exe = System.getProperty(SumoTraciConnection.SUMO_EXE_PROPERTY);
 		if (exe == null) {
 			exe = "sumo";


### PR DESCRIPTION
This pull request contains the following changes:

- Preparations for uploading artifacts to Maven Central (cf. https://github.com/egueli/TraCI4J/issues/22). Added license information and Maven action to sign artifacts with PGP as required by https://maven.apache.org/guides/mini/guide-central-repository-upload.html. 

- Fixes a compilation error in test/java/it/polito/appeal/traci/test/RemoteTraCITest.java